### PR TITLE
Initial tests for provider, cluster version and assign SLA

### DIFF
--- a/rubrikcdm/config.go
+++ b/rubrikcdm/config.go
@@ -2,14 +2,14 @@ package rubrikcdm
 
 import "github.com/rubrikinc/rubrik-sdk-for-go/rubrikcdm"
 
-// Config is per-provider, specifies where to connect to gitlab
+// Config is per-provider, specifies where to connect to Rubrik CDM
 type Config struct {
 	NodeIP   string
 	Username string
 	Password string
 }
 
-// Client returns a *gitlab.Client to interact with the configured gitlab instance
+// Client returns a *rubrik.Client to interact with the configured Rubrik CDM instance
 func (c *Config) Client() (*rubrikcdm.Credentials, error) {
 
 	rubrik := rubrikcdm.Connect(c.NodeIP, c.Username, c.Password)

--- a/rubrikcdm/data_source_rubrik_cluster_version_test.go
+++ b/rubrikcdm/data_source_rubrik_cluster_version_test.go
@@ -12,14 +12,14 @@ func TestAccDataSourceRubrikClusterVersion_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccCheckEnvVariables(t, []string{"rubrik_cdm_expected_version"})
+			testAccCheckEnvVariables(t, []string{"RUBRIK_CDM_EXPECTED_VERSION"})
 		},
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataRubrikClusterVersion(),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.rubrik_cluster_version.version", "cluster_version", os.Getenv("rubrik_cdm_expected_version")),
+					resource.TestCheckResourceAttr("data.rubrik_cluster_version.version", "cluster_version", os.Getenv("RUBRIK_CDM_EXPECTED_VERSION")),
 				),
 			},
 		},

--- a/rubrikcdm/data_source_rubrik_cluster_version_test.go
+++ b/rubrikcdm/data_source_rubrik_cluster_version_test.go
@@ -1,0 +1,33 @@
+package rubrikcdm
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccDataSourceRubrikClusterVersion_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckEnvVariables(t, []string{"rubrik_cdm_expected_version"})
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataRubrikClusterVersion(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.rubrik_cluster_version.version", "cluster_version", os.Getenv("rubrik_cdm_expected_version")),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataRubrikClusterVersion() string {
+	return fmt.Sprintf(`
+data "rubrik_cluster_version" "version" { }
+`)
+}

--- a/rubrikcdm/provider_test.go
+++ b/rubrikcdm/provider_test.go
@@ -1,0 +1,52 @@
+package rubrikcdm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"rubrik": testAccProvider,
+	}
+}
+
+func TestAccProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("rubrik_cdm_username"); v == "" {
+		t.Fatal("rubrik_cdm_username must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("rubrik_cdm_password"); v == "" {
+		t.Fatal("rubrik_cdm_password must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("rubrik_cdm_node_ip"); v == "" {
+		t.Fatal("rubrik_cdm_node_ip must be set for acceptance tests")
+	}
+}
+
+func testAccCheckEnvVariables(t *testing.T, variableNames []string) {
+	for _, name := range variableNames {
+		if v := os.Getenv(name); v == "" {
+			t.Skipf("%s must be set for this acceptance test", name)
+		}
+	}
+}

--- a/rubrikcdm/resource_rubrik_assign_sla_test.go
+++ b/rubrikcdm/resource_rubrik_assign_sla_test.go
@@ -1,0 +1,89 @@
+package rubrikcdm
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/rubrikinc/rubrik-sdk-for-go/rubrikcdm"
+)
+
+func TestAccRubrikAssignSla_basic(t *testing.T) {
+	//vmName := os.Getenv("RUBRIK_CDM_TEST_VM")
+	//slaName := os.Getenv("RUBRIK_CDM_TEST_SLA")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckEnvVariables(t, []string{"RUBRIK_CDM_TEST_VM", "RUBRIK_CDM_TEST_SLA"})
+			testAccCheckRubrikAssignSLAPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRubrikAssignSLADestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRubrikAssignSLAConfig(os.Getenv("RUBRIK_CDM_TEST_VM"), os.Getenv("RUBRIK_CDM_TEST_SLA")),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("rubrik_assign_sla.assign_sla", "object_name", os.Getenv("RUBRIK_CDM_TEST_VM")),
+					resource.TestCheckResourceAttr("rubrik_assign_sla.assign_sla", "sla_name", os.Getenv("RUBRIK_CDM_TEST_SLA")),
+				),
+			},
+		},
+	})
+}
+
+func testAccRubrikAssignSLAConfig(vmName string, slaName string) string {
+	return fmt.Sprintf(`
+resource "rubrik_assign_sla" "assign_sla" {
+	object_name = "%s"
+	object_type = "vmware"
+	sla_name    = "%s"
+	timeout     = 15
+	}
+`, vmName, slaName)
+}
+
+func testAccSLAUnassigned() error {
+	timeout := 15
+	vmName := os.Getenv("RUBRIK_CDM_TEST_VM")
+	rubrik := testAccProvider.Meta().(*rubrikcdm.Credentials)
+
+	vmID, err := rubrik.ObjectID(vmName, "vmware", timeout)
+	if err != nil {
+		return fmt.Errorf(err.Error())
+	}
+
+	//var currentSLAName string
+	vmSummary, err := rubrik.Get("v1", fmt.Sprintf("/vmware/vm/%s", vmID), timeout)
+	if err != nil {
+		return fmt.Errorf(err.Error())
+	}
+
+	slaAssignment := vmSummary.(map[string]interface{})["slaAssignment"].(string)
+	log.Printf("SLA: %s", slaAssignment)
+	if slaAssignment != "Unassigned" {
+		return fmt.Errorf("%s VM has an SLA Domain assigned: %s", vmName, slaAssignment)
+	}
+
+	return nil
+}
+
+func testAccCheckRubrikAssignSLADestroy(s *terraform.State) error {
+	log.Printf("Runng Post-check")
+	err := testAccSLAUnassigned()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func testAccCheckRubrikAssignSLAPreCheck(t *testing.T) {
+	log.Printf("Runng Pre-check")
+	err := testAccSLAUnassigned()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+}

--- a/rubrikcdm/resource_rubrik_assign_sla_test.go
+++ b/rubrikcdm/resource_rubrik_assign_sla_test.go
@@ -12,9 +12,6 @@ import (
 )
 
 func TestAccRubrikAssignSla_basic(t *testing.T) {
-	//vmName := os.Getenv("RUBRIK_CDM_TEST_VM")
-	//slaName := os.Getenv("RUBRIK_CDM_TEST_SLA")
-
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -56,7 +53,6 @@ func testAccSLAUnassigned() error {
 		return fmt.Errorf(err.Error())
 	}
 
-	//var currentSLAName string
 	vmSummary, err := rubrik.Get("v1", fmt.Sprintf("/vmware/vm/%s", vmID), timeout)
 	if err != nil {
 		return fmt.Errorf(err.Error())

--- a/rubrikcdm/resource_rubrik_assign_sla_test.go
+++ b/rubrikcdm/resource_rubrik_assign_sla_test.go
@@ -68,7 +68,7 @@ func testAccSLAUnassigned() error {
 }
 
 func testAccCheckRubrikAssignSLADestroy(s *terraform.State) error {
-	log.Printf("Runng Post-check")
+	log.Printf("Running Post-check")
 	err := testAccSLAUnassigned()
 	if err != nil {
 		return err
@@ -77,7 +77,7 @@ func testAccCheckRubrikAssignSLADestroy(s *terraform.State) error {
 }
 
 func testAccCheckRubrikAssignSLAPreCheck(t *testing.T) {
-	log.Printf("Runng Pre-check")
+	log.Printf("Running Pre-check")
 	err := testAccSLAUnassigned()
 	if err != nil {
 		t.Fatal(err.Error())


### PR DESCRIPTION
# Description

Typo fixes and initial tests for:

* `provider.go`
* `data_source_rubrik_cluster_version.go`
* `resource_rubrik_assign_sla.go`

## Related Issue

#36 & #37 

## Motivation and Context

Why is this change required? What problem does it solve?

Acceptance tests required for Terraform provider certificaiton

## How Has This Been Tested?

Acceptance testing

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-provider-for-terraform/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
