### PR TITLE
Add a check for lower case env variables, enhance timezone acceptance test

### DIFF
--- a/rubrikcdm/provider.go
+++ b/rubrikcdm/provider.go
@@ -1,6 +1,9 @@
 package rubrikcdm
 
 import (
+	"log"
+	"os"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
@@ -8,6 +11,21 @@ import (
 
 // Provider returns a terraform.ResourceProvider.
 func Provider() terraform.ResourceProvider {
+	// Look for environment variables from other Rubrik SDKs, and use them if necessary
+	if os.Getenv("RUBRIK_CDM_NODE_IP") == "" && os.Getenv("rubrik_cdm_node_ip") != "" {
+		os.Setenv("RUBRIK_CDM_NODE_IP", os.Getenv("rubrik_cdm_node_ip"))
+		log.Printf("Setting environment variable RUBRIK_CDM_NODE_IP to match rubrik_cdm_node_ip")
+	}
+
+	if os.Getenv("RUBRIK_CDM_USERNAME") == "" && os.Getenv("rubrik_cdm_username") != "" {
+		os.Setenv("RUBRIK_CDM_USERNAME", os.Getenv("rubrik_cdm_username"))
+		log.Printf("Setting environment variable RUBRIK_CDM_USERNAME to match rubrik_cdm_username")
+	}
+
+	if os.Getenv("RUBRIK_CDM_PASSWORD") == "" && os.Getenv("rubrik_cdm_password") != "" {
+		os.Setenv("RUBRIK_CDM_PASSWORD", os.Getenv("rubrik_cdm_password"))
+		log.Printf("Setting environment variable RUBRIK_CDM_PASSWORD to match rubrik_cdm_password")
+	}
 
 	// The actual provider
 	return &schema.Provider{

--- a/rubrikcdm/resource_rubrik_configure_timezone_test.go
+++ b/rubrikcdm/resource_rubrik_configure_timezone_test.go
@@ -2,15 +2,24 @@ package rubrikcdm
 
 import (
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/rubrikinc/rubrik-sdk-for-go/rubrikcdm"
 )
+
+var currentTz string
 
 func TestAccRubrikConfigureTimezone_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccCheckRubrikConfigureTimezonePreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRubrikTimezoneDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccRubrikConfigureTimezoneConfig("UTC"),
@@ -22,10 +31,62 @@ func TestAccRubrikConfigureTimezone_basic(t *testing.T) {
 	})
 }
 
+func getTimezone() (string, error) {
+	timeout := 15
+	rubrik := testAccProvider.Meta().(*rubrikcdm.Credentials)
+
+	clusterSummary, err := rubrik.Get("v1", "/cluster/me", timeout)
+	if err != nil {
+
+		return "", err
+	}
+
+	currentTimezone := fmt.Sprintf("%v", clusterSummary.(map[string]interface{})["timezone"].(map[string]interface{})["timezone"])
+
+	return currentTimezone, nil
+}
+
+func setTimezone(timezone string) error {
+	timeout := 15
+	rubrik := testAccProvider.Meta().(*rubrikcdm.Credentials)
+
+	_, err := rubrik.ConfigureTimezone(timezone, timeout)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func testAccRubrikConfigureTimezoneConfig(timezone string) string {
 	return fmt.Sprintf(`
 resource "rubrik_configure_timezone" "timezone" {
 	timezone = "%s"
+	timeout = 15
 	}
 `, timezone)
+}
+
+func testAccCheckRubrikConfigureTimezonePreCheck(t *testing.T) {
+	var err error
+
+	log.Printf("Running Pre-check")
+	currentTz, err = getTimezone()
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	if currentTz == "UTC" {
+		t.Fatal("CDM Timezone is already set to UTC. Please set to another timezone before testing.")
+	}
+}
+
+func testAccCheckRubrikTimezoneDestroy(s *terraform.State) error {
+	log.Printf("Running Cleanup. Setting timezone back to %s", currentTz)
+	err := setTimezone(currentTz)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
# Description

* Enhance timezone acceptance test to set the timezone back to the timezone it was originally set to
* Add a check for lower case environment variables

## Related Issue

Resolves #54 
Resolves #56 

## Motivation and Context

* Previously the timezone acceptance test set the timezone to UTC, and verified that it was set. This PR enhances the test so that it checks the timezone first, stores the value, and sets the cluster back to that timezone after the test is complete.
* Add a check for lower case environment variables. Other Rubrik SDKs currently specify environment variables for authentication use lower case. On linux/macOS, these variables are case sensitive, and Terraform providers use environment variables that are upper case.

## How Has This Been Tested?

Acceptance Tests

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-provider-for-terraform/blob/master/CONTRIBUTING.md)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
